### PR TITLE
Starting code for adding error examples to dashboard (UPDATE: Now functional!)

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -101,15 +101,21 @@ with conf_col2:
         st.image(cm_b, caption=f"Confusion Matrix B - {version_b}")
 
 # --- Example Errors ---
-st.subheader("📉 Example Errors")
+st.subheader("💥 Example Errors")
 err_col1, err_col2 = st.columns(2)
 with err_col1:
     if err_a:
-        st.markdown(f"#### False Positive Examples: {err_a['false_positives']}")
+        st.markdown(f"#### False Positive Examples:")
+        st.table(data=err_a['false_positives'][0:min(10, len(err_a['false_positives']))])
+        st.markdown(f"#### False Negative Examples:")
+        st.table(data=err_a['false_negatives'][0:min(10, len(err_a['false_negatives']))])
+
 with err_col2:
     if err_b:
-        st.markdown(f"#### False Positive Examples: {err_b['false_positives']}")
-
+        st.markdown(f"#### False Positive Examples:")
+        st.table(data=err_b['false_positives'][0:min(10, len(err_b['false_positives']))])
+        st.markdown(f"#### False Negative Examples:")
+        st.table(data=err_b['false_negatives'][0:min(10, len(err_b['false_negatives']))])
 
 # --- A/B Prediction ---
 st.subheader("🧪 A/B Prediction Test")

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -43,8 +43,9 @@ def load_model_set(version):
     idf_path = download_file_from_s3(version, "idf.pkl")
     metrics_path = download_file_from_s3(version, "metrics.json")
     matrix_path = download_file_from_s3(version, "confusion_matrix.png")
+    errors_path = download_file_from_s3(version, "error_examples.json")
 
-    if not all([model_path, vec_path, idf_path, metrics_path]):
+    if not all([model_path, vec_path, idf_path, metrics_path, errors_path]):
         st.error("One or more model files could not be downloaded from S3.")
         st.stop()
 
@@ -57,8 +58,10 @@ def load_model_set(version):
 
     with open(metrics_path) as f:
         metrics = json.load(f)
+    with open(errors_path) as f:
+        error_examples = json.load(f)
 
-    return model, vectorizer, metrics, matrix_path
+    return model, vectorizer, metrics, matrix_path, error_examples
 
 # --- UI: Select Versions ---
 available_versions = list_versions()
@@ -74,8 +77,8 @@ with col2:
     version_b = st.selectbox("Model B Version", available_versions, key="b", index=1 if len(available_versions) > 1 else 0)
 
 # --- Load both model versions ---
-model_a, vec_a, metrics_a, cm_a = load_model_set(version_a)
-model_b, vec_b, metrics_b, cm_b = load_model_set(version_b)
+model_a, vec_a, metrics_a, cm_a, err_a = load_model_set(version_a)
+model_b, vec_b, metrics_b, cm_b, err_b = load_model_set(version_b)
 
 # --- Metrics ---
 st.subheader("📊 Evaluation Metrics")
@@ -96,6 +99,17 @@ with conf_col1:
 with conf_col2:
     if cm_b:
         st.image(cm_b, caption=f"Confusion Matrix B - {version_b}")
+
+# --- Example Errors ---
+st.subheader("📉 Example Errors")
+err_col1, err_col2 = st.columns(2)
+with err_col1:
+    if err_a:
+        st.markdown(f"#### False Positive Examples: {err_a['false_positives']}")
+with err_col2:
+    if err_b:
+        st.markdown(f"#### False Positive Examples: {err_b['false_positives']}")
+
 
 # --- A/B Prediction ---
 st.subheader("🧪 A/B Prediction Test")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     depends_on:
       - metaflow
     command: streamlit run dashboard.py --server.port=8501 --server.address=0.0.0.0
+    volumes:
+      - ./dashboard:/app # Mount for automatic updates
 
   metaflow:
     build:

--- a/metaflow_pipeline/sentiment_analysis_flow.py
+++ b/metaflow_pipeline/sentiment_analysis_flow.py
@@ -34,6 +34,8 @@ class SentimentAnalysisFlow(FlowSpec):
 
         X_train, X_val, y_train, y_val = train_test_split(texts, labels, test_size=0.2, random_state=42)
 
+        self.X_val_texts = X_val
+
         self.vectorizer = TfidfVectorizer(max_features=5000, stop_words='english')
         self.X_train = self.vectorizer.fit_transform(X_train)
         self.X_val = self.vectorizer.transform(X_val)
@@ -93,6 +95,15 @@ class SentimentAnalysisFlow(FlowSpec):
         plt.xlabel("Predicted")
         plt.ylabel("Actual")
 
+        errs = {"false_positives": []}
+        for idx, example in enumerate(self.y_val):
+            if self.y_val == 0 and self.y_pred == 1:
+                errs["false_positives"].append(self.X_val_texts[idx])
+
+        self.errors_path = "error_examples.json"
+        with open(self.errors_path, "w") as f:
+            json.dump(errs, f)
+
         self.metrics_path = "metrics.json"
         self.confusion_path = "confusion_matrix.png"
 
@@ -113,7 +124,7 @@ class SentimentAnalysisFlow(FlowSpec):
         s3 = boto3.client('s3')
         version_folder = f"models/{self.version_id}"
 
-        for fname in [self.metrics_path, self.confusion_path]:
+        for fname in [self.metrics_path, self.confusion_path, self.errors_path]:
             s3.upload_file(fname, self.s3_bucket, f"{version_folder}/{fname}")
 
         self.model_url = f"https://{self.s3_bucket}.s3.amazonaws.com/{version_folder}/{self.model_path}"

--- a/metaflow_pipeline/sentiment_analysis_flow.py
+++ b/metaflow_pipeline/sentiment_analysis_flow.py
@@ -2,7 +2,7 @@ from metaflow import FlowSpec, step, Parameter
 from datasets import load_dataset
 from sklearn.model_selection import train_test_split
 from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import classification_report, confusion_matrix, accuracy_score, f1_score
 import matplotlib.pyplot as plt
 import seaborn as sns
@@ -16,6 +16,7 @@ import pickle
 
 class SentimentAnalysisFlow(FlowSpec):
     s3_bucket = Parameter("s3_bucket", help="S3 bucket to store the model")
+    experiment_name = Parameter("experiment_name", help="Short name to identify the experiment you're running")
 
     @step
     def start(self):
@@ -23,7 +24,7 @@ class SentimentAnalysisFlow(FlowSpec):
         dataset = load_dataset("imdb")  # Using IMDb as a proxy for book reviews
         self.raw_data = dataset['train'].shuffle(seed=42).select(range(2000))  # Limit for faster training
         self.test_data = dataset['test'].shuffle(seed=42).select(range(500))
-        self.version_id = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        self.version_id = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S") + f"-{self.experiment_name}"
         self.next(self.prepare_data)
 
     @step
@@ -68,7 +69,7 @@ class SentimentAnalysisFlow(FlowSpec):
     @step
     def train(self):
         print("Training model...")
-        self.model = LogisticRegression(max_iter=1000)
+        self.model = RandomForestClassifier()
         self.model.fit(self.X_train, self.y_train)
 
         self.model_path = "model.joblib"
@@ -95,10 +96,15 @@ class SentimentAnalysisFlow(FlowSpec):
         plt.xlabel("Predicted")
         plt.ylabel("Actual")
 
-        errs = {"false_positives": []}
+        errs = {
+            "false_positives": [],
+            "false_negatives": [],
+        }
         for idx, example in enumerate(self.y_val):
-            if self.y_val == 0 and self.y_pred == 1:
+            if self.y_val[idx] == 0 and y_pred[idx] == 1:
                 errs["false_positives"].append(self.X_val_texts[idx])
+            if self.y_val[idx] == 1 and y_pred[idx] == 0:
+                errs["false_negatives"].append(self.X_val_texts[idx])
 
         self.errors_path = "error_examples.json"
         with open(self.errors_path, "w") as f:


### PR DESCRIPTION
**Here were the problems when I first made this PR and how I solved them:**

**1. False positives not populated in saved JSON file:** Turns out, I was checking that the whole `y_val` and `y_pred` lists were equal to 0 and 1, as opposed to the scores for individual examples. I needed to add `[idx]` to both. 

**2. New section not appearing on restarted, reloaded dashboard:** I mounted a volume for the dashboard in my docker-compose file and then did `docker compose down` and `docker compose up --build -d` to make the dashboard auto-update.

Once I had these two things working, I also: 

- Added false negatives to the flow, in addition to false positives
- Displayed them in tables on the dashboard instead of just in the subheader text 
- Limited the number of examples for each type of error to 10 or all for each model, whichever is _fewer_
- Ran the metaflow flow with these changes with both a random forest classifier and a decision tree classifier so we'll have something to compare in Session 4. 